### PR TITLE
Handle WebGL context creation in browser.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+go:
+  - 1.4
+install:
+  - go get golang.org/x/tools/cmd/vet
+script:
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d ./)
+  - go tool vet ./
+  - go test -v -race ./...

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-goglfw
-======
+glfw
+====
 
-Package goglfw experimentally provides a glfw-like API with desktop (via glfw) and browser (via canvas) backends.
+Package glfw experimentally provides a glfw-like API with desktop (via glfw) and browser (via canvas) backends.
 
 It is used for creating a GL context and receiving events.
 
-**Unstable, incomplete API:** goglfw is currently in development. The API is incomplete and may change.
+**Unstable, incomplete API:** glfw is currently in development. The API is incomplete and may change.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,21 @@
-glfw
-====
+# glfw [![Build Status](https://travis-ci.org/goxjs/glfw.svg?branch=master)](https://travis-ci.org/goxjs/glfw) [![GoDoc](https://godoc.org/github.com/goxjs/glfw?status.svg)](https://godoc.org/github.com/goxjs/glfw)
 
-Package glfw experimentally provides a glfw-like API with desktop (via glfw) and browser (via canvas) backends.
+Package glfw experimentally provides a glfw-like API
+with desktop (via glfw) and browser (via canvas) backends.
 
 It is used for creating a GL context and receiving events.
 
-**Unstable, incomplete API:** glfw is currently in development. The API is incomplete and may change.
+**Unstable, incomplete API:** This package is currently in development. The API is incomplete and may change.
+
+Installation
+------------
+
+```bash
+go get -u github.com/goxjs/glfw
+go get -u -d -tags=js github.com/goxjs/glfw
+```
+
+License
+-------
+
+- [MIT License](http://opensource.org/licenses/mit-license.php)

--- a/browser.go
+++ b/browser.go
@@ -1,6 +1,6 @@
 // +build js
 
-package goglfw
+package glfw
 
 import (
 	"bytes"

--- a/browser.go
+++ b/browser.go
@@ -11,7 +11,6 @@ import (
 	"runtime"
 
 	"github.com/gopherjs/gopherjs/js"
-	"github.com/shurcooL/gogl"
 	"golang.org/x/tools/godoc/vfs"
 	"honnef.co/go/js/dom"
 	"honnef.co/go/js/xhr"
@@ -19,7 +18,11 @@ import (
 
 var document = dom.GetWindow().Document().(dom.HTMLDocument)
 
-func Init() error {
+var contextSwitcher ContextSwitcher
+
+func Init(cs ContextSwitcher) error {
+	contextSwitcher = cs
+
 	return nil
 }
 
@@ -61,22 +64,20 @@ func CreateWindow(_, _ int, title string, monitor *Monitor, share *Window) (*Win
 		document.Body().AppendChild(text)
 	}
 
-	w := &Window{
-		canvas: canvas,
-	}
+	// Use glfw hints.
+	attrs := defaultAttributes()
+	attrs.Alpha = (hints[AlphaBits] > 0)
+	attrs.Antialias = (hints[Samples] > 0)
 
 	// Create GL context.
-	{
-		attrs := gogl.DefaultAttributes()
-		attrs.Alpha = (hints[AlphaBits] > 0)
-		attrs.Antialias = (hints[Samples] > 0)
+	context, err := newContext(canvas.Underlying(), attrs)
+	if err != nil {
+		return nil, err
+	}
 
-		gl, err := gogl.NewContext(w.canvas.Underlying(), attrs)
-		if err != nil {
-			return nil, err
-		}
-
-		w.Context = gl
+	w := &Window{
+		canvas:  canvas,
+		context: context,
 	}
 
 	if w.canvas.Underlying().Get("requestPointerLock") == js.Undefined ||
@@ -268,9 +269,8 @@ func SwapInterval(interval int) error {
 }
 
 type Window struct {
-	Context *gogl.Context
-
-	canvas *dom.HTMLCanvasElement
+	canvas  *dom.HTMLCanvasElement
+	context *js.Object
 
 	missing struct {
 		pointerLock bool
@@ -300,8 +300,16 @@ func PollEvents() error {
 	return nil
 }
 
-func (w *Window) MakeContextCurrent() error {
-	return nil
+func (w *Window) MakeContextCurrent() {
+	contextSwitcher.MakeContextCurrent(w.context)
+}
+
+func DetachCurrentContext() {
+	contextSwitcher.MakeContextCurrent(nil)
+}
+
+func GetCurrentContext() *Window {
+	panic("not yet implemented")
 }
 
 type CursorPosCallback func(w *Window, xpos float64, ypos float64)

--- a/context_webgl.go
+++ b/context_webgl.go
@@ -1,6 +1,6 @@
 // +build js
 
-package goglfw
+package glfw
 
 import (
 	"errors"

--- a/context_webgl.go
+++ b/context_webgl.go
@@ -1,0 +1,56 @@
+// +build js
+
+package goglfw
+
+import (
+	"errors"
+
+	"github.com/gopherjs/gopherjs/js"
+)
+
+func newContext(canvas *js.Object, ca *contextAttributes) (context *js.Object, err error) {
+	if js.Global.Get("WebGLRenderingContext") == js.Undefined {
+		return nil, errors.New("Your browser doesn't appear to support WebGL.")
+	}
+
+	attrs := map[string]bool{
+		"alpha":                           ca.Alpha,
+		"depth":                           ca.Depth,
+		"stencil":                         ca.Stencil,
+		"antialias":                       ca.Antialias,
+		"premultipliedAlpha":              ca.PremultipliedAlpha,
+		"preserveDrawingBuffer":           ca.PreserveDrawingBuffer,
+		"preferLowPowerToHighPerformance": ca.PreferLowPowerToHighPerformance,
+		"failIfMajorPerformanceCaveat":    ca.FailIfMajorPerformanceCaveat,
+	}
+
+	if gl := canvas.Call("getContext", "webgl", attrs); gl != nil {
+		return gl, nil
+	} else if gl := canvas.Call("getContext", "experimental-webgl", attrs); gl != nil {
+		return gl, nil
+	} else {
+		return nil, errors.New("Creating a WebGL context has failed.")
+	}
+}
+
+type contextAttributes struct {
+	Alpha                           bool
+	Depth                           bool
+	Stencil                         bool
+	Antialias                       bool
+	PremultipliedAlpha              bool
+	PreserveDrawingBuffer           bool
+	PreferLowPowerToHighPerformance bool
+	FailIfMajorPerformanceCaveat    bool
+}
+
+func defaultAttributes() *contextAttributes {
+	return &contextAttributes{
+		Alpha:                 false,
+		Depth:                 true,
+		Stencil:               false,
+		Antialias:             false,
+		PremultipliedAlpha:    false,
+		PreserveDrawingBuffer: false,
+	}
+}

--- a/desktop.go
+++ b/desktop.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 
 	"github.com/go-gl/glfw/v3.1/glfw"
-	"github.com/shurcooL/gogl"
 	"golang.org/x/tools/godoc/vfs"
 )
 
@@ -15,7 +14,10 @@ func init() {
 	runtime.LockOSThread()
 }
 
-func Init() error {
+// Init initializes the library.
+//
+// ContextSwitcher is unused on desktop platform.
+func Init(_ ContextSwitcher) error {
 	return glfw.Init()
 }
 
@@ -40,8 +42,6 @@ func CreateWindow(width, height int, title string, monitor *Monitor, share *Wind
 
 	window := &Window{Window: w}
 
-	window.Context = gogl.NewContext()
-
 	return window, err
 }
 
@@ -49,10 +49,12 @@ func SwapInterval(interval int) {
 	glfw.SwapInterval(interval)
 }
 
+func DetachCurrentContext() {
+	glfw.DetachCurrentContext()
+}
+
 type Window struct {
 	*glfw.Window
-
-	Context *gogl.Context
 }
 
 type Monitor struct {

--- a/desktop.go
+++ b/desktop.go
@@ -1,6 +1,6 @@
 // +build !js
 
-package goglfw
+package glfw
 
 import (
 	"os"

--- a/glfw.go
+++ b/glfw.go
@@ -1,8 +1,8 @@
-// Package goglfw experimentally provides a glfw-like API
+// Package glfw experimentally provides a glfw-like API
 // with desktop (via glfw) and browser (via canvas) backends.
 //
 // It is used for creating a GL context and receiving events.
-package goglfw
+package glfw
 
 // ContextSwitcher is a general mechanism for switching between contexts.
 type ContextSwitcher interface {

--- a/goglfw.go
+++ b/goglfw.go
@@ -3,3 +3,10 @@
 //
 // It is used for creating a GL context and receiving events.
 package goglfw
+
+// ContextSwitcher is a general mechanism for switching between contexts.
+type ContextSwitcher interface {
+	// MakeContextCurrent takes a context and makes it current.
+	// If given context is nil, then the current context is detached.
+	MakeContextCurrent(context interface{})
+}

--- a/hint_glfw.go
+++ b/hint_glfw.go
@@ -1,6 +1,6 @@
 // +build !js
 
-package goglfw
+package glfw
 
 import "github.com/go-gl/glfw/v3.1/glfw"
 

--- a/hint_js.go
+++ b/hint_js.go
@@ -1,6 +1,6 @@
 // +build js
 
-package goglfw
+package glfw
 
 var hints = make(map[Hint]int)
 

--- a/tests/events/main.go
+++ b/tests/events/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	glfw "github.com/shurcooL/goglfw"
+	"github.com/goxjs/glfw"
 )
 
 var counter int = -1
@@ -435,7 +435,7 @@ func DropCallback(w *glfw.Window, names []string) {
 }
 
 func main() {
-	err := glfw.Init()
+	err := glfw.Init(nil)
 	if err != nil {
 		panic(err)
 	}
@@ -465,7 +465,6 @@ func main() {
 	window.SetCharModsCallback(CharModsCallback)
 	window.SetDropCallback(DropCallback)
 
-	window.MakeContextCurrent()
 	glfw.SwapInterval(1)
 
 	fmt.Println("Main loop starting.")


### PR DESCRIPTION
- Create `ContextSwitcher` interface.
- Require `ContextSwitcher` in `Init`.
- Allow use of arbitrary gl bindings by removing coupling with
  `github.com/shurcooL/gogl`.

Depends on https://go-review.googlesource.com/8793.
