### PR TITLE
Implement close callback

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -281,6 +281,12 @@ func CreateWindow(_, _ int, title string, monitor *Monitor, share *Window) (*Win
 	document.AddEventListener("touchmove", false, touchHandler)
 	document.AddEventListener("touchend", false, touchHandler)
 
+	document.AddEventListener("beforeunload", false, func(_ dom.Event) {
+		if w.closeCallback != nil {
+			w.closeCallback(w)
+		}
+	})
+
 	// Request first animation frame.
 	js.Global.Call("requestAnimationFrame", animationFrame)
 
@@ -317,6 +323,7 @@ type Window struct {
 	scrollCallback          ScrollCallback
 	framebufferSizeCallback FramebufferSizeCallback
 	sizeCallback            SizeCallback
+	closeCallback           CloseCallback
 
 	touches *js.Object // Hacky mouse-emulation-via-touch.
 }
@@ -838,10 +845,9 @@ func (w *Window) Destroy() {
 type CloseCallback func(w *Window)
 
 func (w *Window) SetCloseCallback(cbfun CloseCallback) (previous CloseCallback) {
-	// TODO: Implement.
-
-	// TODO: Handle previous.
-	return nil
+	previous = w.closeCallback
+	w.closeCallback = cbfun
+	return
 }
 
 type RefreshCallback func(w *Window)


### PR DESCRIPTION
This PR implements the close callback via the browser's `beforeunload` event, which is fired just prior to the page being unloaded.

Note: We should mention there are some limitations on what the callback handler can do with the DOM depending on the browser. In some, opening a dialog is not allowed (to prevent annoying pop-ups).